### PR TITLE
fix url encode message to turn better the reading on telegram channel

### DIFF
--- a/TelegramGlobalException/NotificationService.cs
+++ b/TelegramGlobalException/NotificationService.cs
@@ -18,8 +18,9 @@ namespace TelegramGlobalException
         public async Task Notify(string title, string message)
         {
             var text = new StringBuilder($"*{title}*");
-            text.Append($"{ Uri.EscapeDataString(message)}");
-            text.Append($"*MachineName: {Environment.MachineName}*");
+            text.Append($"%0A{Uri.EscapeDataString(message)}");
+            text.Append($"%0A*MachineName: {Environment.MachineName}*");
+            text.Append($"%0A*Date: {DateTime.Now.ToString("dd/MM/yyyy HH:mm:ss")}*");
 
             using (var httpClient = new HttpClient())
             {


### PR DESCRIPTION
This pull request fix URL encode. Today users get the message as below:
Status code: 500
TraceId: 0HLTBQR7C1LOO:00000008
Action: /api/v2/obter-grupos
Exception: Loja+de+devolu%c3%a7%c3%a3o+inv%c3%a1lida
Date: 07/02/2020 11:19:28
MachineName: MTZTI-N17969

Now, users will be get the message more readeliable 
Status code: 500
TraceId: 0HLTBQR7C1LOO:00000008
Action: /api/v2/obter-grupos
Exception: Loja de devolução inválida
Date: 07/02/2020 11:19:28
MachineName: MTZTI-N17969